### PR TITLE
feat: add supervisor attribution and de-hardcode operator name

### DIFF
--- a/agents/yakob.md
+++ b/agents/yakob.md
@@ -59,13 +59,13 @@ lifecycle and enforces its boundaries.
 
 **At the start of every session, before spawning any shavers, run `/yak-triage`.**
 
-Yak triage asks David for his hard stop time and WIP limit, surveys the yak map,
+Yak triage asks the operator for their hard stop time and WIP limit, surveys the yak map,
 proposes a session plan, and creates a session yak (`session-YYYY-MM-DD-HHMM`)
 with those parameters stored as fields. This pre-commitment happens while
 reflective control is high -- before acceleration flow begins.
 
-Do not spawn any shavers until yak triage is complete and David has confirmed
-the session plan.
+Do not spawn any shavers until yak triage is complete and the operator has
+confirmed the session plan.
 
 **After triage, before the first spawn, start the heartbeat:**
 
@@ -74,7 +74,7 @@ the session plan.
 ```
 
 This runs `yx ls` every 5 minutes so Yakob sees shaver progress between turns.
-If you forget this step, you're flying blind between David's messages.
+If you forget this step, you're flying blind between the operator's messages.
 
 ### During the session: enforce the session yak
 
@@ -85,6 +85,7 @@ session=$(yx ls --format plain | grep "^session-" | head -1)
 session_json=$(yx show "$session" --format json)
 hard_stop=$(echo "$session_json" | jq -r '.fields["hard-stop"]')
 wip_limit=$(echo "$session_json" | jq -r '.fields["wip-limit"]')
+supervisor=$(echo "$session_json" | jq -r '.created_by')
 ```
 
 **Before spawning any shaver**, count the current WIP shavers (read `yx ls`,
@@ -108,13 +109,13 @@ with no break, surface a prompt before the next spawn:
 
 > "You've been shaving for 90 minutes. Take a break before the next shaver?"
 
-Wait for David's response before spawning.
+Wait for the operator's response before spawning.
 
 ### Session end: yak wrap
 
 `/yak-wrap` can be triggered three ways:
 1. **Automatically** by Yakob when hard stop is reached
-2. **Manually** by David at any natural break point ("yak wrap")
+2. **Manually** by the operator at any natural break point ("yak wrap")
 3. **Explicitly** at true end of day
 
 In all cases, `/yak-wrap` harvests done yaks, appends the session report to
@@ -223,6 +224,18 @@ automatically — no changes to Yakob needed.
 
 These are not injected automatically — Yakob must pass them explicitly on every spawn.
 
+### Supervisor attribution
+
+Every spawn prompt **must** include the supervisor identity so shavers can
+stamp `supervised-by` when they start each yak. Read it from the session yak:
+
+```bash
+supervisor=$(yx show "$session" --format json | jq -r '.created_by')
+```
+
+Then include in the prompt: `"Your supervisor is $supervisor — when you
+start each yak, run: echo '$supervisor' | yx field <id> supervised-by"`
+
 ### Example
 
 ```bash
@@ -236,7 +249,10 @@ yak-box spawn \
   --runtime native \
   --yaks auth-login --yaks auth-logout \
   $(echo $skill_flags) \
-  "Work on the auth tasks. For each task, read its context with
+  "Your supervisor is $supervisor. When you start each yak, run:
+   echo '$supervisor' | yx field <id> supervised-by
+
+   Work on the auth tasks. For each task, read its context with
    'yx context --show <name>', do the work, then 'yx done <name>'."
 ```
 
@@ -244,7 +260,7 @@ The spawn command injects yx usage instructions and skill references into the
 worker's prompt. The worker will:
 1. Run `yx ls` to see its tasks
 2. Read context for each task
-3. Do the work in its directory
+3. Stamp `supervised-by` and do the work in its directory
 4. Mark tasks done
 
 ### Scoping workers
@@ -306,7 +322,7 @@ When all tasks show `done` in `yx ls`, the work is complete.
 ## Rules
 
 1. **Triage before spawning.** Run `/yak-triage` at the start of every session.
-   No shavers until the session yak exists and David has confirmed the plan.
+   No shavers until the session yak exists and the operator has confirmed the plan.
 2. **Enforce the session.** Check WIP before every spawn. Check hard stop after
    every shaver finishes. Trigger `/yak-wrap` automatically at hard stop.
 3. **Plan before spawning.** Create all tasks with context first.

--- a/skills/yak-shaving-handbook/SKILL.md
+++ b/skills/yak-shaving-handbook/SKILL.md
@@ -57,12 +57,18 @@ to `yx context` or `yx field` when you need just one piece.
 - Its children (you must complete these before the parent)
 - Its state (todo / wip / done)
 
-Then claim it and announce you've started:
+Then claim it, stamp the supervisor, and announce you've started:
 
 ```bash
 yx start <id>
+echo "$supervisor" | yx field <id> supervised-by
 echo "wip: starting" | yx field <id> agent-status
 ```
+
+`$supervisor` is the human username passed in your spawn prompt (e.g.
+"zgagnon"). This associates the yak with the human who was supervising when
+it was shaved — distinct from `created_by` (who planned it) and
+`assigned-to` (which shaver worked on it).
 
 ## State Transitions
 
@@ -244,6 +250,7 @@ Yakob uses `/loop` to schedule recurring status checks:
 | Read task brief | `yx context <id>` |
 | Read previous agent's notes | `yx field <id> comments.md` |
 | Claim a task | `yx start <id>` |
+| Stamp supervisor | `echo "$supervisor" \| yx field <id> supervised-by` |
 | Report status | `echo "<status>" \| yx field <id> agent-status` |
 | Check for Yakob message | `yx field --show <id> yakob-message` |
 | Heartbeat (Yakob's responsibility) | `/loop 5m yx ls; yx field --show <id> agent-status` |

--- a/skills/yak-triage/SKILL.md
+++ b/skills/yak-triage/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: yak-triage
-description: Sorting the herd at the gate. Session start ritual for Yakob. Establishes the time window and WIP limit, surveys the yak map, and helps David decide what to tackle this session — before acceleration flow begins.
+description: Sorting the herd at the gate. Session start ritual for Yakob. Establishes the time window and WIP limit, surveys the yak map, and helps the operator decide what to tackle this session — before acceleration flow begins.
 ---
 
 # Yak Triage 🔍
@@ -35,7 +35,7 @@ first — then assess what fits within them.
 Accept any format: "12:30", "in 2 hours", "after lunch". Convert to a
 concrete time and confirm it back.
 
-If David says he doesn't know or "as long as it takes" — push back once:
+If the operator doesn't know or says "as long as it takes" — push back once:
 > "A rough estimate is fine. Having no hard stop is what we're trying to fix."
 
 Record as: **hard stop = HH:MM**
@@ -44,7 +44,7 @@ Record as: **hard stop = HH:MM**
 
 > "How many shavers do you want running in parallel? (Default: 3)"
 
-If David accepts the default, proceed. If he says "as many as needed" — note
+If the operator accepts the default, proceed. If they say "as many as needed" — note
 the default of 3 and move on. Don't debate it.
 
 Record as: **WIP limit = N**
@@ -117,13 +117,13 @@ Holding back:
   - [yak-name] — [why skipping: blocked / too big / lower priority]
 ```
 
-If David has must-dos from Phase 1, list those first.
+If the operator has must-dos from Phase 1, list those first.
 
 ### Confirm
 
 > "Does this look right, or do you want to swap anything?"
 
-Wait for David's response. Adjust if needed. Once confirmed, proceed.
+Wait for the operator's response. Adjust if needed. Once confirmed, proceed.
 
 ---
 
@@ -213,7 +213,7 @@ the wip state indicators directly. If the count meets the limit:
 
 | Phase | What | Command |
 |-------|------|---------|
-| Pre-commit | Get hard stop + WIP limit | (ask David) |
+| Pre-commit | Get hard stop + WIP limit | (ask the operator) |
 | Survey | Read the map | `yx ls` |
 | Plan | Propose session focus | (present + confirm) |
 | Commit | Create session yak | `yx add session-YYYY-MM-DD-HHMM` + field sets |
@@ -222,5 +222,5 @@ the wip state indicators directly. If the count meets the limit:
 
 - **Skipping pre-commitment** — surveying the map before setting constraints lets the map set the agenda. Constraints first, always.
 - **Over-filling the plan** — more yaks than the window can hold creates the problem we're solving. Size conservatively.
-- **No hard stop** — if David won't name one, default to 2 hours from now and state it explicitly.
+- **No hard stop** — if the operator won't name one, default to 2 hours from now and state it explicitly.
 - **Ignoring the WIP count of in-flight yaks** — yaks already running count against the limit from the start.

--- a/skills/yak-wrap/SKILL.md
+++ b/skills/yak-wrap/SKILL.md
@@ -51,6 +51,7 @@ yx ls
 yx context --show <name>                    # The brief (Yakob → agent)
 yx field --show <name> agent-status         # The outcome summary
 yx field --show <name> comments.md          # Findings, decisions, surprises
+yx field --show <name> supervised-by        # Who was supervising when it was shaved
 ```
 
 **Collect from every done yak:**
@@ -60,6 +61,7 @@ yx field --show <name> comments.md          # Findings, decisions, surprises
 | `context.md` | What was asked for |
 | `agent-status` | What was delivered (one-line) |
 | `comments.md` | The interesting bits — decisions, surprises, loose ends |
+| `supervised-by` | Which human was supervising when it was shaved |
 
 **Also check `yx log`** for timestamps — this tells you what was shaved
 *today* vs previously. Focus the worklog on today's work.
@@ -119,7 +121,7 @@ Each yak wrap appends a new timestamped section — the session yak's
 Append the following to `{YYYY-MM-DD}-worklog.md` (and print to stdout):
 
 ```markdown
-# Yak Wrap — YYYY-MM-DD HH:MM
+# Yak Wrap — YYYY-MM-DD HH:MM (supervised by @username)
 
 ## Highlights
 


### PR DESCRIPTION
## Summary

- Shavers now stamp `supervised-by` on each yak when they start work, associating it with the human who was supervising the session
- The supervisor identity is derived at runtime from the session yak's `created_by` field (set automatically by `yx` from git config) — no new configuration needed
- All hardcoded human names ("David") replaced with generic "the operator" in yakob.md and yak-triage, making yakthang usable by any team member without editing agent definitions

## How it works

1. Yakob reads `created_by` from the active session yak during triage
2. Yakob passes the supervisor username in every spawn prompt
3. Shavers stamp `echo "$supervisor" | yx field <id> supervised-by` when they `yx start` a yak
4. Yak-wrap harvests `supervised-by` and includes it in the session report header

## Files changed

- **agents/yakob.md** — reads `supervisor` from session yak, passes in spawn prompts, generic prose
- **skills/yak-shaving-handbook/SKILL.md** — adds `supervised-by` to shaver start protocol + quick reference
- **skills/yak-triage/SKILL.md** — "David" → "the operator", fixes gendered pronouns
- **skills/yak-wrap/SKILL.md** — harvests `supervised-by` field, adds to report header template

## Test plan

- [ ] Run a triage session and verify `created_by` is read from the session yak
- [ ] Spawn a shaver and verify it stamps `supervised-by` on the yak
- [ ] Run yak-wrap and verify the supervisor appears in the report header
- [ ] Verify with a different git user to confirm no hardcoded names remain

🐃 Generated with [Claude Code](https://claude.com/claude-code)