### PR TITLE
fix(yak-box): close Zellij tab when native worker finishes

### DIFF
--- a/src/yak-box/internal/zellij/layout.go
+++ b/src/yak-box/internal/zellij/layout.go
@@ -37,7 +37,7 @@ func GenerateLayout(worker *types.Worker, runtimeKind, tool string) string {
 }
 `, worker.DisplayName, paneName)
 	}
-	// Native: tab has cwd; single main pane with wrapper; shell pane is passive.
+	// Native: tab has cwd; single main pane with wrapper; tab closes when wrapper exits.
 	return fmt.Sprintf(`layout {
     tab name="%s" cwd="%s" {
         pane size=1 borderless=true {
@@ -47,11 +47,10 @@ func GenerateLayout(worker *types.Worker, runtimeKind, tool string) string {
             command "bash"
             args "%%WRAPPER%%"
         }
-        pane size=5 name="shell: %s"
         pane size=2 borderless=true {
             plugin location="status-bar"
         }
     }
 }
-`, worker.DisplayName, worker.CWD, paneName, worker.CWD)
+`, worker.DisplayName, worker.CWD, paneName)
 }

--- a/src/yak-box/internal/zellij/layout_test.go
+++ b/src/yak-box/internal/zellij/layout_test.go
@@ -53,9 +53,9 @@ func TestGenerateLayout_Native(t *testing.T) {
 	if !strings.Contains(out, "opencode (build) [native]") {
 		t.Error("layout should have build pane name with runtime")
 	}
-	// Shell pane should have size=5
-	if !strings.Contains(out, `pane size=5 name="shell:`) {
-		t.Error("shell pane should have size=5")
+	// Native layout should NOT have a secondary shell pane
+	if strings.Contains(out, `pane size=5 name="shell:`) {
+		t.Error("native layout should not have a secondary shell pane")
 	}
 	// Main build pane should flex-fill (no size= attribute)
 	if !strings.Contains(out, `pane name="opencode (build) [native]" focus=true`) {


### PR DESCRIPTION
## Summary

Prevents zombie tabs from accumulating when shavers complete work.

- Add `zellij action close-tab` to all native wrappers (claude, cursor, opencode)
- Remove `exec` from cursor/opencode so cleanup runs after the tool exits
- Remove secondary nu shell pane from native layouts
- Replace worker keychain setup with Library symlink for claude wrapper (avoids global keychain mutation and race conditions)

## Test plan

- [x] `go test ./...` passes
- [x] All three tool wrappers (claude, cursor, opencode) include `zellij action close-tab`
- [x] cursor and opencode wrappers do not use `exec` (which would prevent cleanup)
- [x] Native layout no longer generates a secondary shell pane

🤖 Generated with [Claude Code](https://claude.com/claude-code)
Co-Authored-By: Yakoff (Claude) <noreply@anthropic.com>