### PR TITLE
feat(triage): add deflection protocol and pre-spawn checklist

### DIFF
--- a/agents/yakob.md
+++ b/agents/yakob.md
@@ -341,3 +341,17 @@ When all tasks show `done` in `yx ls`, the work is complete.
     the full day.
 11. **Start the heartbeat.** After triage, before the first spawn, run
     `/loop 5m yx ls`. No heartbeat = no visibility between turns.
+12. **Never cross repo boundaries.** Always `--cwd .` from release-workspace.
+    Never `--cwd repos/X` or `--yak-path` pointing elsewhere. Shavers navigate
+    to sub-repos in their prompt, but yx stays rooted in the workspace.
+
+### Pre-Spawn Checklist
+
+Before EVERY `yak-box spawn`, verify ALL of the following:
+1. Session yak exists: `yx ls` shows a `session-` yak in wip state
+2. Heartbeat is running: `/loop` was started after triage
+3. WIP count < limit: count wip yaks (excluding session yak) against wip-limit field
+4. `--cwd` is `.` or the workspace root: NEVER `repos/X` — see rule 12
+
+If ANY check fails, STOP. Do not spawn. Fix the missing piece first.
+If no session yak exists, run `/yak-triage` before proceeding.

--- a/agents/yakob.md
+++ b/agents/yakob.md
@@ -341,9 +341,6 @@ When all tasks show `done` in `yx ls`, the work is complete.
     the full day.
 11. **Start the heartbeat.** After triage, before the first spawn, run
     `/loop 5m yx ls`. No heartbeat = no visibility between turns.
-12. **Never cross repo boundaries.** Always `--cwd .` from release-workspace.
-    Never `--cwd repos/X` or `--yak-path` pointing elsewhere. Shavers navigate
-    to sub-repos in their prompt, but yx stays rooted in the workspace.
 
 ### Pre-Spawn Checklist
 
@@ -351,7 +348,6 @@ Before EVERY `yak-box spawn`, verify ALL of the following:
 1. Session yak exists: `yx ls` shows a `session-` yak in wip state
 2. Heartbeat is running: `/loop` was started after triage
 3. WIP count < limit: count wip yaks (excluding session yak) against wip-limit field
-4. `--cwd` is `.` or the workspace root: NEVER `repos/X` — see rule 12
 
 If ANY check fails, STOP. Do not spawn. Fix the missing piece first.
 If no session yak exists, run `/yak-triage` before proceeding.

--- a/skills/yak-triage/SKILL.md
+++ b/skills/yak-triage/SKILL.md
@@ -55,6 +55,16 @@ Record as: **WIP limit = N**
 
 These get priority placement in the session plan. If none, proceed.
 
+### Deflection Protocol
+
+If the operator responds with a task or question instead of answering triage:
+1. Acknowledge briefly: "Noted — [topic]. That goes on the list."
+2. Do NOT act on it. Do not explore, research, or start the task.
+3. Re-ask the unanswered question.
+4. If deflected a second time: announce defaults and create session yak anyway.
+   "Setting defaults: hard stop = 2 hours from now, WIP limit = 3. Overrule me if that's wrong."
+   Then proceed to Phase 2.
+
 ---
 
 ## Phase 2: Survey the Map


### PR DESCRIPTION
## Summary

- Adds a **deflection protocol** to `skills/yak-triage/SKILL.md`: when an operator responds to triage questions with a task instead of answering, Yakob acknowledges, parks it, and re-asks — falling back to defaults after a second deflection.
- Adds a **pre-spawn checklist** to `agents/yakob.md`: a mechanical gate requiring session yak, heartbeat loop, and WIP check before any shaver is spawned.

## Motivation

Prevents Yakob from skipping triage when operators deflect with task requests. Without this gate, the dopamine loop of "just spawn the thing" bypasses the pre-commitment questions that make sessions tractable.

## Test plan

- [ ] Review `yak-triage` skill — deflection protocol appears in Phase 1
- [ ] Review `agents/yakob.md` — pre-spawn checklist present before shaver spawn steps
- [ ] Run a triage session and attempt to deflect with a task request; verify Yakob parks it and re-asks

🤖 Generated with [Claude Code](https://claude.com/claude-code)