### PR TITLE
feat: add YX_ROOT env var so yx write ops work from sub-repos

### DIFF
--- a/src/yak-box/internal/runtime/helpers.go
+++ b/src/yak-box/internal/runtime/helpers.go
@@ -187,6 +187,7 @@ func generateRunScript(cfg *spawnConfig, workspaceRoot, promptFile, innerScript,
 
 	sb.WriteString(fmt.Sprintf("\t-e WORKER_NAME=\"%s\" \\\n", cfg.worker.WorkerName))
 	sb.WriteString(fmt.Sprintf("\t-e YAK_PATH=\"%s\" \\\n", cfg.worker.YakPath))
+	sb.WriteString(fmt.Sprintf("\t-e YX_ROOT=\"%s\" \\\n", filepath.Dir(cfg.worker.YakPath)))
 	sb.WriteString(fmt.Sprintf("\t-e YAK_TOOL=\"%s\" \\\n", cfg.worker.Tool))
 	sb.WriteString(fmt.Sprintf("\t-e YAK_WORKSPACE=\"%s\" \\\n", cfg.worker.CWD))
 

--- a/src/yak-box/internal/runtime/helpers_test.go
+++ b/src/yak-box/internal/runtime/helpers_test.go
@@ -451,6 +451,9 @@ func TestGenerateNativeWrapperScript_ClaudeHomeSetsWorkerHome(t *testing.T) {
 	if !strings.Contains(content, `export YAK_PATH="/test/yaks"`) {
 		t.Errorf("native claude wrapper missing YAK_PATH, got:\n%s", content)
 	}
+	if !strings.Contains(content, `export YX_ROOT="/test"`) {
+		t.Errorf("native claude wrapper missing YX_ROOT (workspace root), got:\n%s", content)
+	}
 	if !strings.Contains(content, "--dangerously-skip-permissions") {
 		t.Errorf("native claude wrapper missing --dangerously-skip-permissions, got:\n%s", content)
 	}

--- a/src/yak-box/internal/runtime/native.go
+++ b/src/yak-box/internal/runtime/native.go
@@ -249,6 +249,7 @@ export HOME=%q
 %s
 %sexport IS_DEMO=true
 %sexport YAK_PATH="%s"
+export YX_ROOT="%s"
 %s
 unset CLAUDECODE
 MODEL=%q
@@ -274,11 +275,12 @@ trap _restore_keychain EXIT
 # Write PID before running Claude so yak-box stop can find and kill the process tree.
 echo $$ > "%s"
 claude "${CLAUDE_ARGS[@]}" @"$PROMPT_FILE"
-`, filepath.Join(hostHomeDir, ".local", "bin"), homeDir, gitConfigGlobalLine, ghConfigDirLine, gitIdentityLines, shaverNameLine, worker.YakPath, apiKeyLine, worker.Model, promptFile, pidFile)
+`, filepath.Join(hostHomeDir, ".local", "bin"), homeDir, gitConfigGlobalLine, ghConfigDirLine, gitIdentityLines, shaverNameLine, worker.YakPath, filepath.Dir(worker.YakPath), apiKeyLine, worker.Model, promptFile, pidFile)
 	case "cursor":
 		paneName = "cursor (build) [native]"
 		content = fmt.Sprintf(`#!/usr/bin/env bash
 %sexport YAK_PATH="%s"
+export YX_ROOT="%s"
 PROMPT="$(cat "%s")"
 MODEL=%q
 # Write PID before exec so yak-box stop can find and kill the process tree.
@@ -288,17 +290,18 @@ if [[ -n "$MODEL" ]]; then
 else
   exec agent --force --workspace "%s" "$PROMPT"
 fi
-`, shaverNameLine, worker.YakPath, promptFile, worker.Model, pidFile, worker.CWD, worker.CWD)
+`, shaverNameLine, worker.YakPath, filepath.Dir(worker.YakPath), promptFile, worker.Model, pidFile, worker.CWD, worker.CWD)
 	default:
 		paneName = "opencode (build) [native]"
 		content = fmt.Sprintf(`#!/usr/bin/env bash
 %sexport YAK_PATH="%s"
+export YX_ROOT="%s"
 PROMPT="$(cat "%s")"
 # Write PID before exec so yak-box stop can find and kill the process tree.
 # exec replaces this process, so $$ will be the PID of opencode.
 echo $$ > "%s"
 exec opencode --prompt "$PROMPT" --agent build
-`, shaverNameLine, worker.YakPath, promptFile, pidFile)
+`, shaverNameLine, worker.YakPath, filepath.Dir(worker.YakPath), promptFile, pidFile)
 	}
 	return content, paneName
 }


### PR DESCRIPTION
## Summary

- Adds `YX_ROOT` env var support to the `yx` CLI: when set, `discover_git_root()` returns it instead of walking up the directory tree with `git2::Repository::discover()`. This is the fundamental fix.
- Updates `yak-box spawn` to set `YX_ROOT=<workspace_root>` in all spawned worker scripts (native: claude, cursor, opencode; sandboxed: docker `-e` flag). The workspace root is `filepath.Dir(YakPath)`.

## Problem

`yx write ops (done, field, state) fail when a shaver cd's into a sub-repo` because `git2::Repository::discover()` finds the sub-repo's git root, not the workspace root. The workspace's `.yaks` directory is not present under the sub-repo root, so yaks can't be found.

Repro:
```bash
cd repos/releng/release
yx ls           # works (pure filesystem walk, uses YAK_PATH)
yx done <name>  # fails: yak not found
```

## Fix

When `YX_ROOT` is set, `yx` uses it as the git root for all operations. `yak-box spawn` sets it automatically to the parent of `.yaks`.

## Related

- yx CLI changes: https://github.com/zgagnon/yaks/tree/fix/yx-root-env-var
  (needs merge into `mattwynne/yaks` first, or submodule URL updated to fork)

## Test plan

- [ ] `yx` Cucumber test: `@fullstack` scenario in `git_checks.feature` verifies `yx done` succeeds from a nested git repo with `YX_ROOT` set
- [ ] yak-box tests: all Go tests pass (`go test ./...`)
- [ ] Manual: spawn a native worker and verify `YX_ROOT` is exported in the wrapper script