### PR TITLE
fix(native): merge host hooks into worker settings.json

### DIFF
--- a/docs/research/pretooluse-hook-bypass-in-native-workers.md
+++ b/docs/research/pretooluse-hook-bypass-in-native-workers.md
@@ -1,0 +1,112 @@
+# PreToolUse Hook Bypass in Native Workers
+
+**Date:** 2026-03-20
+**Investigator:** Yaklyn
+**Status:** Diagnosed — fix not yet implemented
+
+## Problem
+
+The global `PreToolUse` hook that blocks bare `git` commands is configured in `~/.claude/settings.json` on the operator's machine. It fires correctly for the orchestrator session but does **not** fire for shavers spawned via `yak-box --runtime native`.
+
+## Hook Configuration
+
+`/Users/zell/.claude/settings.json`:
+```json
+"hooks": {
+  "PreToolUse": [
+    {
+      "matcher": "Bash",
+      "hooks": [
+        {
+          "type": "command",
+          "command": "bash ~/.claude/hooks/block-git.sh",
+          "statusMessage": "Checking for bare git commands..."
+        }
+      ]
+    }
+  ]
+}
+```
+
+`~/.claude/hooks/block-git.sh` denies any Bash command matching `(^|[;&|]+\s*)git(\s|$)`.
+
+## Root Cause 1 — Worker `settings.json` Is Written Without Hooks
+
+`internal/runtime/native.go:setupClaudeSettings()` writes a fresh `settings.json` to
+`<workerHome>/.claude/settings.json`. It only populates:
+
+- `apiKeyHelper` (when API key auth is in use)
+- `statusLine` (when `goccc` is installed)
+- `skipDangerousModePermissionPrompt: true` (always)
+
+The `hooks` section from the operator's real `~/.claude/settings.json` is **never read,
+copied, or merged**. Claude Code running in the worker reads only the worker's settings
+file and finds no hooks.
+
+**Confirmed:** `.yak-boxes/@home/Yaklyn/.claude/settings.json` contains:
+```json
+{"skipDangerousModePermissionPrompt": true}
+```
+
+No hooks directory exists at `.yak-boxes/@home/Yaklyn/.claude/hooks/`.
+
+## Root Cause 2 — `HOME` Override Severs the Hook Chain
+
+The native worker wrapper script (`run.sh`) sets `export HOME=<workerHome>` so that Claude
+Code finds worker-specific skills and settings at `<workerHome>/.claude/` rather than the
+operator's real home. This is intentional isolation.
+
+A side-effect: the hook command `bash ~/.claude/hooks/block-git.sh` would expand `~` to
+`<workerHome>`, not `/Users/zell`. Even if the `hooks` config were naively copied, the
+script path would resolve to a non-existent file in the worker home.
+
+## Why It Works for the Orchestrator
+
+The orchestrator runs with the real `HOME=/Users/zell`. Claude Code reads
+`/Users/zell/.claude/settings.json`, which contains the `hooks` section, and resolves
+`~/.claude/hooks/block-git.sh` correctly.
+
+## Execution Path Summary
+
+```
+yak-box spawn --runtime native
+  └─ runSpawn()
+       └─ SpawnNativeWorker()
+            ├─ setupClaudeSettings(homeDir)   <- writes minimal settings.json, no hooks
+            └─ generateNativeWrapperScript()  <- emits: export HOME=<workerHome>
+                                                         claude --dangerously-skip-permissions @prompt.txt
+
+Worker Claude process:
+  HOME = <workerHome>
+  reads <workerHome>/.claude/settings.json  -> {"skipDangerousModePermissionPrompt": true}
+  no hooks -> PreToolUse never fires
+```
+
+## Proposed Fix
+
+Two changes are needed together:
+
+### 1. Merge host hooks into the worker's `settings.json`
+
+In `setupClaudeSettings(homeDir, apiKey string)`, accept the host home dir as an additional
+parameter. Before writing `settings.json`, read the operator's
+`<hostHomeDir>/.claude/settings.json`, extract the `hooks` key, and merge it into the
+worker settings map.
+
+### 2. Rewrite `~` to an absolute path in hook commands
+
+When merging, walk every hook `command` string and replace a leading `~/` with
+`<hostHomeDir>/`. This ensures the hook script resolves to the real host path even though
+the worker runs with `HOME=<workerHome>`.
+
+Alternatively, change the hook registration in the host settings to use an absolute path
+from the start (e.g. `/Users/zell/.claude/hooks/block-git.sh`), making the rewrite step
+unnecessary. Step 1 is still required regardless.
+
+### Scope of change
+
+- `internal/runtime/native.go` — `setupClaudeSettings()` signature + merge logic
+- The call site in `generateNativeWrapperScript()` already has `hostHomeDir` in scope,
+  so threading it through is straightforward.
+- No changes needed to the sandboxed runtime (the Docker container gets a fully isolated
+  environment by design and does not inherit host hooks).

--- a/src/yak-box/internal/runtime/helpers_test.go
+++ b/src/yak-box/internal/runtime/helpers_test.go
@@ -563,7 +563,7 @@ func TestSetupClaudeSettings_PreseededClaudeJSON(t *testing.T) {
 	homeDir := t.TempDir()
 	apiKey := "sk-ant-test-xxxxxxxxxxxxxxxxxxxx"
 
-	if err := setupClaudeSettings(homeDir, apiKey); err != nil {
+	if err := setupClaudeSettings(homeDir, "", apiKey); err != nil {
 		t.Fatalf("setupClaudeSettings returned error: %v", err)
 	}
 

--- a/src/yak-box/internal/runtime/native.go
+++ b/src/yak-box/internal/runtime/native.go
@@ -32,16 +32,16 @@ func SpawnNativeWorker(worker *types.Worker, prompt string, homeDir string) (pid
 
 	pidFile = filepath.Join(workerDir, "worker.pid")
 
+	hostHomeDir := os.Getenv("HOME")
+
 	// Resolve API key once; shared by setupClaudeSettings and generateNativeWrapperScript.
 	apiKey := ""
 	if worker.Tool == "claude" {
 		apiKey = resolveAnthropicKey()
-		if err := setupClaudeSettings(homeDir, apiKey); err != nil {
+		if err := setupClaudeSettings(homeDir, hostHomeDir, apiKey); err != nil {
 			fmt.Fprintf(os.Stderr, "Warning: failed to setup Claude settings: %v\n", err)
 		}
 	}
-
-	hostHomeDir := os.Getenv("HOME")
 	wrapperContent, _ := generateNativeWrapperScript(worker, homeDir, hostHomeDir, promptFile, pidFile, apiKey)
 
 	wrapperScript := filepath.Join(workerDir, "run.sh")
@@ -308,7 +308,9 @@ exec opencode --prompt "$PROMPT" --agent build
 // auth non-interactively. When no API key is present (OAuth mode), the helper
 // is omitted so Claude Code falls through to its OAuth credentials.
 // It also preserves statusline config when goccc exists.
-func setupClaudeSettings(homeDir, apiKey string) error {
+// When hostHomeDir is non-empty, hooks from <hostHomeDir>/.claude/settings.json
+// are merged in, with leading ~/ in command strings rewritten to absolute paths.
+func setupClaudeSettings(homeDir, hostHomeDir, apiKey string) error {
 	claudeDir := filepath.Join(homeDir, ".claude")
 	if err := os.MkdirAll(claudeDir, 0755); err != nil {
 		return fmt.Errorf("failed to create .claude directory: %w", err)
@@ -359,6 +361,11 @@ func setupClaudeSettings(homeDir, apiKey string) error {
 			"command": "goccc -statusline",
 		}
 	}
+	if hostHomeDir != "" {
+		if hooks := readHostHooks(hostHomeDir); hooks != nil {
+			settings["hooks"] = rewriteHookPaths(hooks, hostHomeDir)
+		}
+	}
 	settingsData, err := json.MarshalIndent(settings, "", "  ")
 	if err != nil {
 		return fmt.Errorf("failed to marshal Claude settings: %w", err)
@@ -369,4 +376,47 @@ func setupClaudeSettings(homeDir, apiKey string) error {
 	}
 
 	return nil
+}
+
+// readHostHooks reads the "hooks" value from <hostHomeDir>/.claude/settings.json.
+// Returns nil if the file is missing, unreadable, or contains no "hooks" key.
+func readHostHooks(hostHomeDir string) any {
+	data, err := os.ReadFile(filepath.Join(hostHomeDir, ".claude", "settings.json"))
+	if err != nil {
+		return nil
+	}
+	var hostSettings map[string]any
+	if err := json.Unmarshal(data, &hostSettings); err != nil {
+		return nil
+	}
+	return hostSettings["hooks"]
+}
+
+// rewriteHookPaths walks the hooks structure and replaces a leading "~/" in
+// every "command" string with hostHomeDir+"/". Workers run with HOME set to the
+// worker directory, so ~ would otherwise resolve to the wrong path.
+func rewriteHookPaths(v any, hostHomeDir string) any {
+	switch val := v.(type) {
+	case map[string]any:
+		result := make(map[string]any, len(val))
+		for k, child := range val {
+			if k == "command" {
+				if s, ok := child.(string); ok {
+					child = strings.ReplaceAll(s, "~/", hostHomeDir+"/")
+				}
+			} else {
+				child = rewriteHookPaths(child, hostHomeDir)
+			}
+			result[k] = child
+		}
+		return result
+	case []any:
+		result := make([]any, len(val))
+		for i, item := range val {
+			result[i] = rewriteHookPaths(item, hostHomeDir)
+		}
+		return result
+	default:
+		return v
+	}
 }

--- a/src/yak-box/internal/runtime/native_test.go
+++ b/src/yak-box/internal/runtime/native_test.go
@@ -117,7 +117,115 @@ func TestSetupClaudeSettings_NoGocccSkipsStatusline(t *testing.T) {
 	// When goccc is not in PATH, setupClaudeSettings should still create .claude dirs and remote-settings
 	// but may skip settings.json with statusline. We already have TestSetupClaudeSettings_PreseededClaudeJSON
 	// in helpers_test. This test just ensures setupClaudeSettings with empty apiKey doesn't panic.
-	if err := setupClaudeSettings(homeDir, ""); err != nil {
+	if err := setupClaudeSettings(homeDir, "", ""); err != nil {
 		t.Fatalf("setupClaudeSettings with empty key: %v", err)
+	}
+}
+
+func TestSetupClaudeSettings_MergesHostHooks(t *testing.T) {
+	workerHome := t.TempDir()
+	hostHome := t.TempDir()
+
+	hostClaudeDir := filepath.Join(hostHome, ".claude")
+	if err := os.MkdirAll(hostClaudeDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	hostSettings := `{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash ~/.claude/hooks/block-git.sh",
+            "statusMessage": "Checking for bare git commands..."
+          }
+        ]
+      }
+    ]
+  }
+}`
+	if err := os.WriteFile(filepath.Join(hostClaudeDir, "settings.json"), []byte(hostSettings), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := setupClaudeSettings(workerHome, hostHome, ""); err != nil {
+		t.Fatalf("setupClaudeSettings: %v", err)
+	}
+
+	data, err := os.ReadFile(filepath.Join(workerHome, ".claude", "settings.json"))
+	if err != nil {
+		t.Fatalf("reading worker settings.json: %v", err)
+	}
+	content := string(data)
+
+	if !strings.Contains(content, "PreToolUse") {
+		t.Error("worker settings.json should contain PreToolUse hook")
+	}
+	// ~ should be rewritten to the absolute host home path
+	if strings.Contains(content, "~/.claude") {
+		t.Error("worker settings.json should not contain ~/  — tilde should be rewritten")
+	}
+	expectedCmd := "bash " + hostHome + "/.claude/hooks/block-git.sh"
+	if !strings.Contains(content, expectedCmd) {
+		t.Errorf("worker settings.json should contain rewritten path %q, got:\n%s", expectedCmd, content)
+	}
+}
+
+func TestSetupClaudeSettings_NoHostHooksWhenHostSettingsMissing(t *testing.T) {
+	workerHome := t.TempDir()
+	hostHome := t.TempDir() // no .claude/settings.json written
+
+	if err := setupClaudeSettings(workerHome, hostHome, ""); err != nil {
+		t.Fatalf("setupClaudeSettings: %v", err)
+	}
+
+	data, err := os.ReadFile(filepath.Join(workerHome, ".claude", "settings.json"))
+	if err != nil {
+		t.Fatalf("reading worker settings.json: %v", err)
+	}
+	if strings.Contains(string(data), "hooks") {
+		t.Errorf("worker settings.json should not contain hooks when host settings.json is absent, got:\n%s", data)
+	}
+}
+
+func TestRewriteHookPaths_ReplacesLeadingTilde(t *testing.T) {
+	hooks := map[string]any{
+		"PreToolUse": []any{
+			map[string]any{
+				"matcher": "Bash",
+				"hooks": []any{
+					map[string]any{
+						"type":    "command",
+						"command": "bash ~/.claude/hooks/block-git.sh",
+					},
+				},
+			},
+		},
+	}
+	result := rewriteHookPaths(hooks, "/Users/testuser")
+	outer, ok := result.(map[string]any)
+	if !ok {
+		t.Fatal("expected map result")
+	}
+	items := outer["PreToolUse"].([]any)
+	inner := items[0].(map[string]any)
+	hookList := inner["hooks"].([]any)
+	hookEntry := hookList[0].(map[string]any)
+	cmd := hookEntry["command"].(string)
+	if cmd != "bash /Users/testuser/.claude/hooks/block-git.sh" {
+		t.Errorf("expected rewritten path, got %q", cmd)
+	}
+}
+
+func TestRewriteHookPaths_LeavesAbsolutePathsAlone(t *testing.T) {
+	hooks := map[string]any{
+		"command": "/absolute/path/hook.sh",
+	}
+	result := rewriteHookPaths(hooks, "/Users/testuser")
+	m := result.(map[string]any)
+	if m["command"] != "/absolute/path/hook.sh" {
+		t.Errorf("absolute path should not be modified, got %q", m["command"])
 	}
 }

--- a/src/yak-box/internal/runtime/sandboxed.go
+++ b/src/yak-box/internal/runtime/sandboxed.go
@@ -132,7 +132,9 @@ func SpawnSandboxedWorker(ctx context.Context, opts ...SpawnOption) error {
 	// Prepare Claude settings using the shared native+sandbox setup path.
 	// This keeps Claude bootstrap behavior consistent across runtimes; sandbox
 	// differs only in execution inside a container.
-	if err := setupClaudeSettings(cfg.homeDir, resolveAnthropicKey()); err != nil {
+	// Pass empty hostHomeDir: sandboxed workers run in isolated containers and
+	// must not inherit host hooks by design.
+	if err := setupClaudeSettings(cfg.homeDir, "", resolveAnthropicKey()); err != nil {
 		return fmt.Errorf("failed to setup Claude settings: %w. Suggestion: Ensure the .yak-boxes directory is writable", err)
 	}
 


### PR DESCRIPTION
## Summary

- PreToolUse hooks from `~/.claude/settings.json` were silently bypassed for native workers because `setupClaudeSettings()` wrote a minimal settings.json with no hooks
- Worker `HOME` override caused any tilde-relative paths to resolve to the worker directory, not the host home
- `setupClaudeSettings()` now accepts `hostHomeDir`, reads the `hooks` key from the host settings, rewrites `~/` to absolute paths, and merges the result into the worker settings

## Changes

- `internal/runtime/native.go`: `setupClaudeSettings()` takes `hostHomeDir` parameter; adds `readHostHooks()` and `rewriteHookPaths()` helpers; moves `hostHomeDir` resolution before the call
- `internal/runtime/sandboxed.go`: passes `""` for `hostHomeDir` (sandboxed containers intentionally isolated)
- `internal/runtime/native_test.go` / `helpers_test.go`: updated callers; added tests for hook merging, tilde rewriting, and missing host settings

## Test plan

- [x] `go test ./...` passes
- [x] Worker `settings.json` contains `hooks` from host `~/.claude/settings.json`
- [x] Hook `~/` paths are rewritten to absolute `hostHomeDir/` paths
- [x] No hooks injected when host `settings.json` is absent
- [x] Sandboxed runtime unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)