### PR TITLE
discuss: repo boundary rule for Yakob

### DIFF
--- a/agents/yakob.md
+++ b/agents/yakob.md
@@ -371,3 +371,11 @@ When all tasks show `done` in `yx ls`, the work is complete.
     the full day.
 11. **Start the heartbeat.** After triage, before the first spawn, run
     `/loop 5m yx ls`. No heartbeat = no visibility between turns.
+12. **Never cross repo boundaries.** Always `--cwd .` from release-workspace.
+    Never `--cwd repos/X` or `--yak-path` pointing elsewhere. Shavers navigate
+    to sub-repos in their prompt, but yx stays rooted in the workspace.
+
+### Pre-Spawn Checklist
+
+Before EVERY `yak-box spawn`, verify ALL of the following:
+4. `--cwd` is `.` or the workspace root: NEVER `repos/X` — see rule 12


### PR DESCRIPTION
Extracted from PR #6 for separate discussion.

## The proposal

Rule 12 for Yakob: **"Never cross repo boundaries."** Always `--cwd .` from the workspace root. Never `--cwd repos/X`. Shavers navigate to sub-repos via their prompt, but yx stays rooted in the workspace.

## Why this might be valuable

When `--cwd` points into a sub-repo, yx operations (`done`, `field`, etc.) can fail because `git2::Repository::discover()` finds the sub-repo's `.git` instead of the workspace root's. PR #7 (`YX_ROOT` env var) is a mechanical fix for this, but rule 12 is the behavioural prevention — don't go there in the first place.

It also keeps workers conceptually scoped: one workspace, one `.yaks/` tree, one source of truth.

## How this interacts with `@home` and worktrees

Workers already get isolated home directories at `.yak-boxes/@home/<worker>/`. When `--auto-worktree` is used, `--cwd` points to the worktree path, not the workspace root. Both of these are legitimate cases where `--cwd` is _not_ `.` — so a blanket "always `--cwd .`" rule is too strict.

The real constraint is narrower: **don't point `--cwd` into a nested git repo within the workspace** (e.g. `repos/releng/release`). Worktrees and `@home` directories are fine because they're managed by yak-box and don't confuse yx's root discovery.

Should the rule be rewritten to say "never `--cwd` into a sub-repo" rather than "always `--cwd .`"? 

## Does PR #7 invalidate this?
Does the `YX_ROOT` fix make this rule unnecessary?
