### PR TITLE
quality: yak-box remove restating docstrings

### DIFF
--- a/src/yak-box/internal/errors/errors.go
+++ b/src/yak-box/internal/errors/errors.go
@@ -1,23 +1,4 @@
-// Package errors provides a typed error system for exit code handling.
-//
-// This package defines specific error types that map to distinct exit codes,
-// enabling consistent error handling and reporting throughout the application.
-//
-// Exit code conventions:
-//   - 1: General runtime errors (e.g., file I/O, network issues)
-//   - 2: Validation/usage errors (e.g., invalid flags, malformed input)
-//
-// Example usage:
-//
-//	if err := validateInput(input); err != nil {
-//		return errors.NewValidationError("invalid input format", err)
-//	}
-//
-//	if err := readFile(path); err != nil {
-//		return errors.NewRuntimeError("failed to read file", err)
-//	}
-//
-//	exitCode := errors.GetExitCode(err)
+// Package errors provides typed errors that map to CLI exit codes (1=runtime, 2=validation).
 package errors
 
 import (
@@ -26,14 +7,12 @@ import (
 	"strings"
 )
 
-// ValidationError represents a validation or usage error.
-// These errors indicate improper input or configuration and should result in exit code 2.
+// ValidationError maps to exit code 2 (improper input or configuration).
 type ValidationError struct {
 	Message string
 	Cause   error
 }
 
-// Error implements the error interface for ValidationError.
 func (e *ValidationError) Error() string {
 	if e.Cause != nil {
 		return fmt.Sprintf("%s: %v", e.Message, e.Cause)
@@ -41,19 +20,16 @@ func (e *ValidationError) Error() string {
 	return e.Message
 }
 
-// Unwrap implements the error unwrapping interface for error chain inspection.
 func (e *ValidationError) Unwrap() error {
 	return e.Cause
 }
 
-// RuntimeError represents a runtime error.
-// These errors indicate failures during execution (I/O, network, etc.) and should result in exit code 1.
+// RuntimeError maps to exit code 1 (I/O, network, and other execution failures).
 type RuntimeError struct {
 	Message string
 	Cause   error
 }
 
-// Error implements the error interface for RuntimeError.
 func (e *RuntimeError) Error() string {
 	if e.Cause != nil {
 		return fmt.Sprintf("%s: %v", e.Message, e.Cause)
@@ -61,13 +37,10 @@ func (e *RuntimeError) Error() string {
 	return e.Message
 }
 
-// Unwrap implements the error unwrapping interface for error chain inspection.
 func (e *RuntimeError) Unwrap() error {
 	return e.Cause
 }
 
-// NewValidationError creates a new ValidationError with the given message and cause.
-// Returns an error interface to support standard Go error handling.
 func NewValidationError(msg string, cause error) error {
 	return &ValidationError{
 		Message: msg,
@@ -76,8 +49,6 @@ func NewValidationError(msg string, cause error) error {
 }
 
 // CombineValidation aggregates multiple validation errors into a single ValidationError.
-// If the slice is empty, returns nil. The message is formatted as "Validation errors:\n" plus
-// each error on its own line with "  - " prefix, for consistent CLI output across commands.
 func CombineValidation(errs []error) error {
 	if len(errs) == 0 {
 		return nil
@@ -92,8 +63,6 @@ func CombineValidation(errs []error) error {
 	return NewValidationError(strings.TrimSuffix(b, "\n"), nil)
 }
 
-// NewRuntimeError creates a new RuntimeError with the given message and cause.
-// Returns an error interface to support standard Go error handling.
 func NewRuntimeError(msg string, cause error) error {
 	return &RuntimeError{
 		Message: msg,
@@ -101,11 +70,7 @@ func NewRuntimeError(msg string, cause error) error {
 	}
 }
 
-// GetExitCode extracts the appropriate exit code from an error.
-// Returns:
-//   - 2 for ValidationError
-//   - 1 for RuntimeError
-//   - 1 for unknown errors
+// GetExitCode returns 2 for ValidationError, 1 for everything else.
 func GetExitCode(err error) int {
 	var validationErr *ValidationError
 	var runtimeErr *RuntimeError

--- a/src/yak-box/internal/runtime/options.go
+++ b/src/yak-box/internal/runtime/options.go
@@ -9,7 +9,6 @@ import (
 	"github.com/wellmaintained/yakthang/src/yak-box/pkg/types"
 )
 
-// Commander abstracts command execution for testing
 type Commander interface {
 	CommandContext(ctx context.Context, name string, args ...string) *exec.Cmd
 }
@@ -29,10 +28,8 @@ type spawnConfig struct {
 	commander Commander
 }
 
-// SpawnOption configures the spawn process
 type SpawnOption func(*spawnConfig) error
 
-// WithWorker sets the worker configuration
 func WithWorker(worker *types.Worker) SpawnOption {
 	return func(c *spawnConfig) error {
 		c.worker = worker
@@ -40,7 +37,6 @@ func WithWorker(worker *types.Worker) SpawnOption {
 	}
 }
 
-// WithPrompt sets the prompt string
 func WithPrompt(prompt string) SpawnOption {
 	return func(c *spawnConfig) error {
 		c.prompt = prompt
@@ -48,7 +44,6 @@ func WithPrompt(prompt string) SpawnOption {
 	}
 }
 
-// WithResourceProfile sets the resource profile
 func WithResourceProfile(profile types.ResourceProfile) SpawnOption {
 	return func(c *spawnConfig) error {
 		c.profile = profile
@@ -56,7 +51,6 @@ func WithResourceProfile(profile types.ResourceProfile) SpawnOption {
 	}
 }
 
-// WithHomeDir sets the home directory
 func WithHomeDir(homeDir string) SpawnOption {
 	return func(c *spawnConfig) error {
 		c.homeDir = homeDir
@@ -64,7 +58,6 @@ func WithHomeDir(homeDir string) SpawnOption {
 	}
 }
 
-// WithDevConfig sets the devcontainer configuration
 func WithDevConfig(devConfig *devcontainer.Config) SpawnOption {
 	return func(c *spawnConfig) error {
 		c.devConfig = devConfig
@@ -72,7 +65,6 @@ func WithDevConfig(devConfig *devcontainer.Config) SpawnOption {
 	}
 }
 
-// WithCommander sets a custom commander for testing
 func WithCommander(cmdr Commander) SpawnOption {
 	return func(c *spawnConfig) error {
 		c.commander = cmdr

--- a/src/yak-box/internal/ui/output.go
+++ b/src/yak-box/internal/ui/output.go
@@ -8,26 +8,18 @@ import (
 	"github.com/fatih/color"
 )
 
-// Success prints a green-colored message to stderr.
-// Respects NO_COLOR environment variable and TTY detection.
 func Success(format string, args ...interface{}) {
 	color.New(color.FgGreen).Fprintf(os.Stderr, format, args...)
 }
 
-// Warning prints a yellow-colored message to stderr.
-// Respects NO_COLOR environment variable and TTY detection.
 func Warning(format string, args ...interface{}) {
 	color.New(color.FgYellow).Fprintf(os.Stderr, format, args...)
 }
 
-// Error prints a red-colored message to stderr.
-// Respects NO_COLOR environment variable and TTY detection.
 func Error(format string, args ...interface{}) {
 	color.New(color.FgRed).Fprintf(os.Stderr, format, args...)
 }
 
-// Info prints a cyan-colored message to stderr.
-// Respects NO_COLOR environment variable and TTY detection.
 func Info(format string, args ...interface{}) {
 	color.New(color.FgCyan).Fprintf(os.Stderr, format, args...)
 }


### PR DESCRIPTION
## Summary
- Stripped AI-generated boilerplate docstrings that merely restate function names from `pkg/errors/errors.go`, `internal/ui/output.go`, and `internal/runtime/options.go`

## Context
Nightshift code quality session. Yaklyn completed this yak before stalling on subsequent tasks.

🐃 Nightshift work by Yaklyn, supervised by Yakob

🤖 Generated with [Claude Code](https://claude.com/claude-code)